### PR TITLE
Update package.json for Vite 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
 		"svelte-check": "^4.0.9",
 		"tslib": "^2.8.1",
 		"typescript": "^5.6.3",
-		"vite": "^5.4.11"
+		"vite": "^5.4.11 || ^6.0.5"
 	},
 	"dependencies": {
-		"@sveltejs/vite-plugin-svelte": "^4.0.1",
+		"@sveltejs/vite-plugin-svelte": "^4.0.1 || ^5.0.3",
 		"colorjs.io": "^0.5.2",
 		"cssnano": "^7.0.6",
 		"cssnano-preset-advanced": "^7.0.6",


### PR DESCRIPTION
Vite 6.0 was released a month ago ; Svelte released quite a few updates in December during their Advent. 

This removes peer dependencies alerts. 

https://github.com/vitejs/vite/releases
https://svelte.dev/blog/advent-of-svelte
